### PR TITLE
Exclude user_img field from getAllUsers response

### DIFF
--- a/src/services/00-userInfo/userInfoService.js
+++ b/src/services/00-userInfo/userInfoService.js
@@ -8,7 +8,7 @@ exports.createUser = async (userData) => {
 exports.getAllUsers = async () => {
     return await UserInfo.findAll(
         {attributes: {
-                exclude: ['user_pw', 'user_img'] // user_id와 user_img를 제외
+                exclude: ['user_pw'] // user_pw를 제외
             }}
     );
 }


### PR DESCRIPTION
The getAllUsers function now excludes only the user_pw field from its response, removing the unintended exclusion of the user_img field.