### PR TITLE
Add is_available field to updateUser request

### DIFF
--- a/src/services/00-userInfo/userInfoService.js
+++ b/src/services/00-userInfo/userInfoService.js
@@ -49,6 +49,7 @@ exports.updateUser = async (userData) => {
         user_like: userData.user_like,
         user_dislike: userData.user_dislike,
         is_agree_privacy: userData.is_agree_privacy,
+        is_available: userData.is_available,
     }, {
         where: {
             user_idx: userData.user_idx


### PR DESCRIPTION
Include the missing `is_available` field in the `updateUser` request to ensure complete user data handling.